### PR TITLE
Implement online OLS with sklearn-like API

### DIFF
--- a/notebooks/Lecture_2_Intro_OOP.ipynb
+++ b/notebooks/Lecture_2_Intro_OOP.ipynb
@@ -1,0 +1,200 @@
+# Demo: univariate OnlineOLSNaive with __add__/__iadd__
+
+xs = np.array([1, 2, 3, 4, 5], dtype=float)
+ys = 2 * xs + 1  # slope=2, intercept=1
+
+m = OnlineOLSNaive()
+for x, y in zip(xs[:3], ys[:3]):
+    m += (x, y)
+
+m2 = m + (xs[3], ys[3])  # create a new model with one more observation
+m2 += (xs[4], ys[4])     # in-place add last observation
+
+print("slope:", round(m2.slope, 6))
+print("intercept:", round(m2.intercept, 6))
+print("score:", round(m2.score(xs, ys), 6))class OnlineOLS:
+    """Streaming multivariate OLS using running sufficient statistics.
+
+    Maintains X'X and X'y sums to avoid storing data. For stability, we
+    center features/targets online via Welford updates for means and use
+    a normal-equations solve with small ridge if needed.
+
+    __add__/__iadd__ accept either (x, y) for a single sample or
+    (X, y) batched where X is shape (n_samples, n_features).
+    """
+    def __init__(self, n_features: Optional[int] = None, ridge: float = 0.0):
+        self.n_features = n_features
+        self.ridge = float(ridge)
+
+        self.n = 0
+        self.mean_x = None  # (d,)
+        self.mean_y = 0.0
+        self.Sxx = None     # centered sum of outer products (d,d)
+        self.Sxy = None     # centered cross sum (d,)
+
+        self._coef = None
+        self._intercept = None
+
+    def _ensure_dim(self, x: np.ndarray):
+        d = x.shape[-1]
+        if self.n_features is None:
+            self.n_features = d
+        elif d != self.n_features:
+            raise ValueError(f"Expected n_features={self.n_features}, got {d}")
+
+    def add(self, x: Union[np.ndarray, Iterable[float]], y: Union[float, np.ndarray]):
+        X = np.atleast_2d(np.asarray(x, dtype=float))
+        y = np.asarray(y, dtype=float).reshape(-1)
+        if X.shape[0] != y.shape[0]:
+            raise ValueError("X and y must have same number of samples")
+        self._ensure_dim(X)
+
+        d = self.n_features
+        if self.mean_x is None:
+            self.mean_x = np.zeros(d)
+            self.Sxx = np.zeros((d, d))
+            self.Sxy = np.zeros(d)
+            self.mean_y = 0.0
+
+        for i in range(X.shape[0]):
+            xi = X[i]
+            yi = float(y[i])
+            self.n += 1
+            # Update means (Welford)
+            dx = xi - self.mean_x
+            dy = yi - self.mean_y
+            self.mean_x += dx / self.n
+            self.mean_y += dy / self.n
+            # Update centered sums
+            self.Sxx += np.outer(xi - self.mean_x, dx)
+            self.Sxy += (xi - self.mean_x) * dy
+
+        # Invalidate cached params
+        self._coef = None
+        self._intercept = None
+
+    def __iadd__(self, obs):
+        x, y = obs
+        self.add(x, y)
+        return self
+
+    def __add__(self, obs):
+        x, y = obs
+        new = OnlineOLS(self.n_features, self.ridge)
+        new.n = self.n
+        new.mean_x = None if self.mean_x is None else self.mean_x.copy()
+        new.mean_y = self.mean_y
+        new.Sxx = None if self.Sxx is None else self.Sxx.copy()
+        new.Sxy = None if self.Sxy is None else self.Sxy.copy()
+        new.add(x, y)
+        return new
+
+    def _fit_if_needed(self):
+        if self._coef is not None:
+            return
+        if self.n == 0 or self.Sxx is None:
+            raise ValueError("No data.")
+        # Coefficients from centered normal equations
+        A = self.Sxx.copy()
+        if self.ridge > 0:
+            A.flat[:: self.n_features + 1] += self.ridge
+        try:
+            coef_centered = np.linalg.solve(A, self.Sxy)
+        except np.linalg.LinAlgError:
+            coef_centered = np.linalg.lstsq(A, self.Sxy, rcond=None)[0]
+        # Convert centered coef to non-centered parameters
+        b = coef_centered
+        a = self.mean_y - float(np.dot(b, self.mean_x))
+        self._coef = b
+        self._intercept = a
+
+    @property
+    def coef_(self) -> np.ndarray:
+        self._fit_if_needed()
+        return self._coef
+
+    @property
+    def intercept_(self) -> float:
+        self._fit_if_needed()
+        return self._intercept
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        self._fit_if_needed()
+        X = np.asarray(X, dtype=float)
+        return X @ self._coef + self._intercept
+
+    def score(self, X: np.ndarray, y: np.ndarray) -> float:
+        yhat = self.predict(X)
+        u = y - yhat
+        v = y - y.mean()
+        den = float(np.dot(v, v))
+        return 1.0 - float(np.dot(u, u)) / den if den != 0.0 else 0.0
+class OnlineOLSNaive:
+    """Streaming univariate OLS via simple running sums.
+
+    __add__/__iadd__ treat (x, y) as an observation.
+    """
+    def __init__(self):
+        self.n = 0
+        self.Sx = 0.0
+        self.Sy = 0.0
+        self.Sxx = 0.0
+        self.Sxy = 0.0
+
+    def add(self, x: float, y: float) -> None:
+        self.n += 1
+        self.Sx += x
+        self.Sy += y
+        self.Sxx += x * x
+        self.Sxy += x * y
+
+    def __iadd__(self, obs: Tuple[float, float]):
+        x, y = obs
+        self.add(x, y)
+        return self
+
+    def __add__(self, obs: Tuple[float, float]):
+        x, y = obs
+        new = OnlineOLSNaive()
+        new.n = self.n
+        new.Sx = self.Sx
+        new.Sy = self.Sy
+        new.Sxx = self.Sxx
+        new.Sxy = self.Sxy
+        new.add(x, y)
+        return new
+
+    @property
+    def slope(self) -> float:
+        if self.n < 2:
+            raise ValueError("Need at least two points for slope.")
+        n, Sx, Sy, Sxx, Sxy = self.n, self.Sx, self.Sy, self.Sxx, self.Sxy
+        den = n * Sxx - Sx * Sx
+        if den == 0:
+            raise ZeroDivisionError("Denominator is zero (all x identical?).")
+        return (n * Sxy - Sx * Sy) / den
+
+    @property
+    def intercept(self) -> float:
+        if self.n == 0:
+            raise ValueError("No data.")
+        return (self.Sy - self.slope * self.Sx) / self.n
+
+    def predict(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        return self.intercept + self.slope * x
+
+    def score(self, X: np.ndarray, y: np.ndarray) -> float:
+        yhat = self.predict(X)
+        u = y - yhat
+        v = y - y.mean()
+        den = float(np.dot(v, v))
+        return 1.0 - float(np.dot(u, u)) / den if den != 0.0 else 0.0
+# Imports for this section
+import math
+import numpy as np
+from typing import Optional, Tuple, Union, Iterable
+## What does `__add__` mean here?
+
+We'll define `model + (x, y)` to mean "return a new model with this observation added," and `model += (x, y)` to update in place. This mirrors numeric addition semantics but for our data structure. We'll start with a univariate naive estimator, then generalize to multivariate with numerically stable updates.# CME 193 - Lec 2: Object-Oriented Programming via an Online OLS Example
+
+We'll motivate OOP with a scientific/ML flavored example: a streaming (online) ordinary least squares estimator. We'll build a class that ingests observations one-by-one, overloads `__add__`/`__iadd__` to "add an observation", and exposes an API similar to scikit-learn (`coef_`, `intercept_`, `predict`, `score`).

--- a/notebooks/Lecture_2_Intro_OOP.ipynb
+++ b/notebooks/Lecture_2_Intro_OOP.ipynb
@@ -1,4 +1,145 @@
-# Demo: univariate OnlineOLSNaive with __add__/__iadd__
+# Demo: streaming UnivariateOnlineOLS
+xs = np.array([0, 1, 2, 3], dtype=float)
+ys = 3 + 2 * xs
+
+m = UnivariateOnlineOLS(fit_intercept=True)
+for x, y in zip(xs, ys):
+    m += (x, y)
+print("Online: slope=", round(m.slope, 4), " intercept=", round(m.intercept, 4), " R^2=", round(m.score(xs, ys), 4))
+
+m0 = UnivariateOnlineOLS(fit_intercept=False)
+for x, y in zip(xs, ys):
+    m0 += (x, y)
+print("Online (no intercept): slope=", round(m0.slope, 4), " intercept=", round(m0.intercept, 4), " R^2=", round(m0.score(xs, ys), 4))# Demo: batch UnivariateOLS
+xs = np.array([0, 1, 2, 3], dtype=float)
+ys = 3 + 2 * xs
+
+m = UnivariateOLS(fit_intercept=True).fit(xs, ys)
+print("Batch: slope=", round(m.slope_, 4), " intercept=", round(m.intercept_, 4), " R^2=", round(m.score(xs, ys), 4))
+
+m0 = UnivariateOLS(fit_intercept=False).fit(xs, ys)
+print("Batch (no intercept): slope=", round(m0.slope_, 4), " intercept=", round(m0.intercept_, 4), " R^2=", round(m0.score(xs, ys), 4))import numpy as np
+from typing import Tuple, Union
+
+class UnivariateOLS:
+    def __init__(self, fit_intercept: bool = True):
+        self.fit_intercept = bool(fit_intercept)
+        self.intercept_ = None
+        self.slope_ = None
+
+    def fit(self, X: np.ndarray, y: np.ndarray):
+        X = np.asarray(X, dtype=float).reshape(-1)
+        y = np.asarray(y, dtype=float).reshape(-1)
+        if X.shape[0] != y.shape[0]:
+            raise ValueError("X and y must have same length")
+        n = X.shape[0]
+        Sx = X.sum()
+        Sy = y.sum()
+        Sxx = float(np.dot(X, X))
+        Sxy = float(np.dot(X, y))
+        if self.fit_intercept:
+            den = n * Sxx - Sx * Sx
+            if den == 0:
+                raise ZeroDivisionError("Denominator is zero (all x identical?).")
+            b = (n * Sxy - Sx * Sy) / den
+            a = (Sy - b * Sx) / n
+        else:
+            if Sxx == 0:
+                raise ZeroDivisionError("Sxx is zero (all x are zero?).")
+            b = Sxy / Sxx
+            a = 0.0
+        self.intercept_ = float(a)
+        self.slope_ = float(b)
+        return self
+
+    def predict(self, X: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        if self.slope_ is None:
+            raise ValueError("Model not fit.")
+        return self.intercept_ + self.slope_ * X
+
+    def score(self, X: np.ndarray, y: np.ndarray) -> float:
+        yhat = self.predict(X)
+        u = y - yhat
+        v = y - y.mean() if self.fit_intercept else y
+        den = float(np.dot(v, v))
+        return 1.0 - float(np.dot(u, u)) / den if den != 0.0 else 0.0
+
+class UnivariateOnlineOLS:
+    def __init__(self, fit_intercept: bool = True):
+        self.fit_intercept = bool(fit_intercept)
+        self.n = 0
+        self.Sx = 0.0
+        self.Sy = 0.0
+        self.Sxx = 0.0
+        self.Sxy = 0.0
+        self._a = None
+        self._b = None
+
+    def add(self, x: float, y: float) -> None:
+        self.n += 1
+        self.Sx += x
+        self.Sy += y
+        self.Sxx += x * x
+        self.Sxy += x * y
+        self._a = self._b = None
+
+    def __iadd__(self, obs: Tuple[float, float]):
+        x, y = obs
+        self.add(float(x), float(y))
+        return self
+
+    def __add__(self, obs: Tuple[float, float]):
+        x, y = obs
+        new = UnivariateOnlineOLS(self.fit_intercept)
+        new.n, new.Sx, new.Sy, new.Sxx, new.Sxy = self.n, self.Sx, self.Sy, self.Sxx, self.Sxy
+        new.add(float(x), float(y))
+        return new
+
+    def _fit_if_needed(self):
+        if self._b is not None:
+            return
+        if self.n == 0:
+            raise ValueError("No data.")
+        if self.fit_intercept:
+            den = self.n * self.Sxx - self.Sx * self.Sx
+            if den == 0:
+                raise ZeroDivisionError("Denominator is zero (all x identical?).")
+            b = (self.n * self.Sxy - self.Sx * self.Sy) / den
+            a = (self.Sy - b * self.Sx) / self.n
+        else:
+            if self.Sxx == 0:
+                raise ZeroDivisionError("Sxx is zero (all x are zero?).")
+            b = self.Sxy / self.Sxx
+            a = 0.0
+        self._a, self._b = float(a), float(b)
+
+    @property
+    def slope(self) -> float:
+        self._fit_if_needed()
+        return float(self._b)
+
+    @property
+    def intercept(self) -> float:
+        self._fit_if_needed()
+        return float(self._a)
+
+    def predict(self, X: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        self._fit_if_needed()
+        return self._a + self._b * X
+
+    def score(self, X: np.ndarray, y: np.ndarray) -> float:
+        yhat = self.predict(X)
+        u = y - yhat
+        v = y - y.mean() if self.fit_intercept else y
+        den = float(np.dot(v, v))
+        return 1.0 - float(np.dot(u, u)) / den if den != 0.0 else 0.0
+# Univariate OLS via OOP (Optional Intercept)
+
+We implement ordinary least squares for one variable in two forms:
+- UnivariateOLS: batch fit
+- UnivariateOnlineOLS: streaming updates with `__add__`/`__iadd__`
+
+Both support `fit_intercept=True/False`.# Demo: univariate OnlineOLSNaive with __add__/__iadd__
 
 xs = np.array([1, 2, 3, 4, 5], dtype=float)
 ys = 2 * xs + 1  # slope=2, intercept=1

--- a/notebooks/Lecture_2_Online_OLS.ipynb
+++ b/notebooks/Lecture_2_Online_OLS.ipynb
@@ -1,0 +1,207 @@
+from sklearn.linear_model import LinearRegression
+
+# Make a multivariate dataset
+X = np.array([[1, 1], [1, 2], [2, 2], [2, 3]], dtype=float)
+y = X @ np.array([1.0, 2.0]) + 3.0
+
+# Fit with OnlineOLS (streaming)
+ome = OnlineOLS(n_features=2)
+ome += (X[:2], y[:2])  # batch add
+for i in range(2, len(X)):
+    ome += (X[i], y[i])
+
+print("OnlineOLS coef_:", np.round(ome.coef_, 6))
+print("OnlineOLS intercept_:", round(ome.intercept_, 6))
+print("OnlineOLS R^2:", round(ome.score(X, y), 6))
+
+# Fit with sklearn
+reg = LinearRegression().fit(X, y)
+print("sklearn coef_:", np.round(reg.coef_, 6))
+print("sklearn intercept_:", round(reg.intercept_, 6))
+print("sklearn R^2:", round(reg.score(X, y), 6))
+
+# Predict a new point
+print("OnlineOLS predict [[3,5]]:", ome.predict(np.array([[3.0, 5.0]])))
+print("sklearn  predict [[3,5]]:", reg.predict(np.array([[3.0, 5.0]])))### Compare with scikit-learn
+
+Fit the same small dataset with both `OnlineOLS` and `sklearn.linear_model.LinearRegression` to check parameters and R^2.# Demo: univariate OnlineOLSNaive
+xs = np.array([1, 2, 3, 4, 5], dtype=float)
+ys = 2 * xs + 1
+m = OnlineOLSNaive()
+for x, y in zip(xs, ys):
+    m += (x, y)
+print("slope:", round(m.slope, 6))
+print("intercept:", round(m.intercept, 6))
+print("score:", round(m.score(xs, ys), 6))class OnlineOLS:
+    """Streaming multivariate OLS using running sufficient statistics.
+
+    Maintains X'X and X'y via centered online updates (Welford). Exposes
+    sklearn-like properties/methods: coef_, intercept_, predict, score.
+    """
+    def __init__(self, n_features: Optional[int] = None, ridge: float = 0.0):
+        self.n_features = n_features
+        self.ridge = float(ridge)
+        self.n = 0
+        self.mean_x = None
+        self.mean_y = 0.0
+        self.Sxx = None
+        self.Sxy = None
+        self._coef = None
+        self._intercept = None
+
+    def _ensure_dim(self, X: np.ndarray):
+        d = X.shape[-1]
+        if self.n_features is None:
+            self.n_features = d
+        elif d != self.n_features:
+            raise ValueError(f"Expected n_features={self.n_features}, got {d}")
+
+    def add(self, x: Union[np.ndarray, Iterable[float]], y: Union[float, np.ndarray]):
+        X = np.atleast_2d(np.asarray(x, dtype=float))
+        y = np.asarray(y, dtype=float).reshape(-1)
+        if X.shape[0] != y.shape[0]:
+            raise ValueError("X and y must have same number of samples")
+        self._ensure_dim(X)
+
+        d = self.n_features
+        if self.mean_x is None:
+            self.mean_x = np.zeros(d)
+            self.Sxx = np.zeros((d, d))
+            self.Sxy = np.zeros(d)
+            self.mean_y = 0.0
+
+        for i in range(X.shape[0]):
+            xi = X[i]
+            yi = float(y[i])
+            self.n += 1
+            dx = xi - self.mean_x
+            dy = yi - self.mean_y
+            self.mean_x += dx / self.n
+            self.mean_y += dy / self.n
+            self.Sxx += np.outer(xi - self.mean_x, dx)
+            self.Sxy += (xi - self.mean_x) * dy
+
+        self._coef = None
+        self._intercept = None
+
+    def __iadd__(self, obs):
+        x, y = obs
+        self.add(x, y)
+        return self
+
+    def __add__(self, obs):
+        x, y = obs
+        new = OnlineOLS(self.n_features, self.ridge)
+        new.n = self.n
+        new.mean_x = None if self.mean_x is None else self.mean_x.copy()
+        new.mean_y = self.mean_y
+        new.Sxx = None if self.Sxx is None else self.Sxx.copy()
+        new.Sxy = None if self.Sxy is None else self.Sxy.copy()
+        new.add(x, y)
+        return new
+
+    def _fit_if_needed(self):
+        if self._coef is not None:
+            return
+        if self.n == 0 or self.Sxx is None:
+            raise ValueError("No data.")
+        A = self.Sxx.copy()
+        if self.ridge > 0:
+            A.flat[:: self.n_features + 1] += self.ridge
+        try:
+            b = np.linalg.solve(A, self.Sxy)
+        except np.linalg.LinAlgError:
+            b = np.linalg.lstsq(A, self.Sxy, rcond=None)[0]
+        a = self.mean_y - float(np.dot(b, self.mean_x))
+        self._coef = b
+        self._intercept = a
+
+    @property
+    def coef_(self) -> np.ndarray:
+        self._fit_if_needed()
+        return self._coef
+
+    @property
+    def intercept_(self) -> float:
+        self._fit_if_needed()
+        return self._intercept
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        self._fit_if_needed()
+        X = np.asarray(X, dtype=float)
+        return X @ self._coef + self._intercept
+
+    def score(self, X: np.ndarray, y: np.ndarray) -> float:
+        y = np.asarray(y, dtype=float)
+        yhat = self.predict(X)
+        u = y - yhat
+        v = y - y.mean()
+        den = float(np.dot(v, v))
+        return 1.0 - float(np.dot(u, u)) / den if den != 0.0 else 0.0
+class OnlineOLSNaive:
+    """Streaming univariate OLS via simple running sums.
+
+    __add__/__iadd__ treat (x, y) as an observation.
+    """
+    def __init__(self):
+        self.n = 0
+        self.Sx = 0.0
+        self.Sy = 0.0
+        self.Sxx = 0.0
+        self.Sxy = 0.0
+
+    def add(self, x: float, y: float) -> None:
+        self.n += 1
+        self.Sx += x
+        self.Sy += y
+        self.Sxx += x * x
+        self.Sxy += x * y
+
+    def __iadd__(self, obs: Tuple[float, float]):
+        x, y = obs
+        self.add(x, y)
+        return self
+
+    def __add__(self, obs: Tuple[float, float]):
+        x, y = obs
+        new = OnlineOLSNaive()
+        new.n = self.n
+        new.Sx = self.Sx
+        new.Sy = self.Sy
+        new.Sxx = self.Sxx
+        new.Sxy = self.Sxy
+        new.add(x, y)
+        return new
+
+    @property
+    def slope(self) -> float:
+        if self.n < 2:
+            raise ValueError("Need at least two points for slope.")
+        n, Sx, Sy, Sxx, Sxy = self.n, self.Sx, self.Sy, self.Sxx, self.Sxy
+        den = n * Sxx - Sx * Sx
+        if den == 0:
+            raise ZeroDivisionError("Denominator is zero (all x identical?).")
+        return (n * Sxy - Sx * Sy) / den
+
+    @property
+    def intercept(self) -> float:
+        if self.n == 0:
+            raise ValueError("No data.")
+        return (self.Sy - self.slope * self.Sx) / self.n
+
+    def predict(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        return self.intercept + self.slope * x
+
+    def score(self, X: np.ndarray, y: np.ndarray) -> float:
+        yhat = self.predict(X)
+        u = y - yhat
+        v = y - y.mean()
+        den = float(np.dot(v, v))
+        return 1.0 - float(np.dot(u, u)) / den if den != 0.0 else 0.0
+import numpy as np
+from typing import Optional, Tuple, Union, Iterable
+## What does `__add__` mean here?
+
+We define `model + (x, y)` to return a new model with that observation included, and `model += (x, y)` to update the model in-place. This is a natural, readable notation for streaming updates.# CME 193 - Lec 2: OOP via an Online OLS Example
+
+We’ll motivate OOP with a scientific/ML-flavored example: a streaming (online) ordinary least squares estimator. We’ll build classes that ingest observations one-by-one, overload `__add__`/`__iadd__` to “add an observation”, and expose an API similar to scikit-learn (`coef_`, `intercept_`, `predict`, `score`).

--- a/notebooks/Lecture_2_Online_OLS.ipynb
+++ b/notebooks/Lecture_2_Online_OLS.ipynb
@@ -1,4 +1,103 @@
-from sklearn.linear_model import LinearRegression
+# Tiny demo: with intercept vs. through origin
+xs = np.array([0, 1, 2, 3], dtype=float)
+ys = 3 + 2 * xs
+
+m_with = OnlineOLS1D(fit_intercept=True)
+for x, y in zip(xs, ys):
+    m_with += (x, y)
+
+m_no = OnlineOLS1D(fit_intercept=False)
+for x, y in zip(xs, ys):
+    m_no += (x, y)
+
+print("With intercept:  slope=", round(m_with.slope, 4), " intercept=", round(m_with.intercept, 4))
+print("Through origin: slope=", round(m_no.slope, 4),   " intercept=", round(m_no.intercept, 4))
+print("R^2 (with intercept):", round(m_with.score(xs, ys), 4))
+print("R^2 (through origin):", round(m_no.score(xs, ys), 4))import numpy as np
+from typing import Tuple, Union
+
+class OnlineOLS1D:
+    def __init__(self, fit_intercept: bool = True):
+        self.fit_intercept = bool(fit_intercept)
+        self.n = 0
+        self.Sx = 0.0
+        self.Sy = 0.0
+        self.Sxx = 0.0
+        self.Sxy = 0.0
+        # cached params
+        self._a = None  # intercept
+        self._b = None  # slope
+
+    def add(self, x: float, y: float) -> None:
+        self.n += 1
+        self.Sx += x
+        self.Sy += y
+        self.Sxx += x * x
+        self.Sxy += x * y
+        self._a = self._b = None
+
+    def __iadd__(self, obs: Tuple[float, float]):
+        x, y = obs
+        self.add(float(x), float(y))
+        return self
+
+    def __add__(self, obs: Tuple[float, float]):
+        x, y = obs
+        new = OnlineOLS1D(self.fit_intercept)
+        new.n, new.Sx, new.Sy, new.Sxx, new.Sxy = self.n, self.Sx, self.Sy, self.Sxx, self.Sxy
+        new.add(float(x), float(y))
+        return new
+
+    def _fit_if_needed(self):
+        if self._b is not None:
+            return
+        if self.n == 0:
+            raise ValueError("No data.")
+        if self.fit_intercept:
+            n, Sx, Sy, Sxx, Sxy = self.n, self.Sx, self.Sy, self.Sxx, self.Sxy
+            den = n * Sxx - Sx * Sx
+            if den == 0:
+                raise ZeroDivisionError("Denominator is zero (all x identical?).")
+            b = (n * Sxy - Sx * Sy) / den
+            a = (Sy - b * Sx) / n
+        else:
+            # through origin: minimize sum (y - b x)^2 → b = Sxy / Sxx
+            if self.Sxx == 0:
+                raise ZeroDivisionError("Sxx is zero (all x are zero?).")
+            b = self.Sxy / self.Sxx
+            a = 0.0
+        self._a, self._b = a, b
+
+    @property
+    def slope(self) -> float:
+        self._fit_if_needed()
+        return float(self._b)
+
+    @property
+    def intercept(self) -> float:
+        self._fit_if_needed()
+        return float(self._a)
+
+    def predict(self, x: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        self._fit_if_needed()
+        return self._a + self._b * x
+
+    def score(self, X: np.ndarray, y: np.ndarray) -> float:
+        yhat = self.predict(X)
+        u = y - yhat
+        if self.fit_intercept:
+            v = y - y.mean()
+        else:
+            v = y  # compare to 0-model when no intercept
+        den = float(np.dot(v, v))
+        return 1.0 - float(np.dot(u, u)) / den if den != 0.0 else 0.0
+# Basic OLS (1 variable) with optional intercept
+
+We start simple: one feature x and a target y. We'll support two cases:
+- with an intercept (y ≈ a + b x)
+- through the origin (intercept = 0, y ≈ b x)
+
+We'll also allow adding data via `model += (x, y)` to emphasize OOP and magic methods.from sklearn.linear_model import LinearRegression
 
 # Make a multivariate dataset
 X = np.array([[1, 1], [1, 2], [2, 2], [2, 3]], dtype=float)

--- a/notebooks/Lecture_2_Univariate_OLS.ipynb
+++ b/notebooks/Lecture_2_Univariate_OLS.ipynb
@@ -1,0 +1,140 @@
+# Demo: streaming UnivariateOnlineOLS
+xs = np.array([0, 1, 2, 3], dtype=float)
+ys = 3 + 2 * xs
+
+m = UnivariateOnlineOLS(fit_intercept=True)
+for x, y in zip(xs, ys):
+    m += (x, y)
+print("Online: slope=", round(m.slope, 4), " intercept=", round(m.intercept, 4), " R^2=", round(m.score(xs, ys), 4))
+
+m0 = UnivariateOnlineOLS(fit_intercept=False)
+for x, y in zip(xs, ys):
+    m0 += (x, y)
+print("Online (no intercept): slope=", round(m0.slope, 4), " intercept=", round(m0.intercept, 4), " R^2=", round(m0.score(xs, ys), 4))# Demo: batch UnivariateOLS
+xs = np.array([0, 1, 2, 3], dtype=float)
+ys = 3 + 2 * xs
+
+m = UnivariateOLS(fit_intercept=True).fit(xs, ys)
+print("Batch: slope=", round(m.slope_, 4), " intercept=", round(m.intercept_, 4), " R^2=", round(m.score(xs, ys), 4))
+
+m0 = UnivariateOLS(fit_intercept=False).fit(xs, ys)
+print("Batch (no intercept): slope=", round(m0.slope_, 4), " intercept=", round(m0.intercept_, 4), " R^2=", round(m0.score(xs, ys), 4))class UnivariateOnlineOLS:
+    def __init__(self, fit_intercept: bool = True):
+        self.fit_intercept = bool(fit_intercept)
+        self.n = 0
+        self.Sx = 0.0
+        self.Sy = 0.0
+        self.Sxx = 0.0
+        self.Sxy = 0.0
+        self._a = None
+        self._b = None
+
+    def add(self, x: float, y: float) -> None:
+        self.n += 1
+        self.Sx += x
+        self.Sy += y
+        self.Sxx += x * x
+        self.Sxy += x * y
+        self._a = self._b = None
+
+    def __iadd__(self, obs: Tuple[float, float]):
+        x, y = obs
+        self.add(float(x), float(y))
+        return self
+
+    def __add__(self, obs: Tuple[float, float]):
+        x, y = obs
+        new = UnivariateOnlineOLS(self.fit_intercept)
+        new.n, new.Sx, new.Sy, new.Sxx, new.Sxy = self.n, self.Sx, self.Sy, self.Sxx, self.Sxy
+        new.add(float(x), float(y))
+        return new
+
+    def _fit_if_needed(self):
+        if self._b is not None:
+            return
+        if self.n == 0:
+            raise ValueError("No data.")
+        if self.fit_intercept:
+            den = self.n * self.Sxx - self.Sx * self.Sx
+            if den == 0:
+                raise ZeroDivisionError("Denominator is zero (all x identical?).")
+            b = (self.n * self.Sxy - self.Sx * self.Sy) / den
+            a = (self.Sy - b * self.Sx) / self.n
+        else:
+            if self.Sxx == 0:
+                raise ZeroDivisionError("Sxx is zero (all x are zero?).")
+            b = self.Sxy / self.Sxx
+            a = 0.0
+        self._a, self._b = float(a), float(b)
+
+    @property
+    def slope(self) -> float:
+        self._fit_if_needed()
+        return float(self._b)
+
+    @property
+    def intercept(self) -> float:
+        self._fit_if_needed()
+        return float(self._a)
+
+    def predict(self, X: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        self._fit_if_needed()
+        return self._a + self._b * X
+
+    def score(self, X: np.ndarray, y: np.ndarray) -> float:
+        yhat = self.predict(X)
+        u = y - yhat
+        v = y - y.mean() if self.fit_intercept else y
+        den = float(np.dot(v, v))
+        return 1.0 - float(np.dot(u, u)) / den if den != 0.0 else 0.0
+class UnivariateOLS:
+    def __init__(self, fit_intercept: bool = True):
+        self.fit_intercept = bool(fit_intercept)
+        self.intercept_ = None
+        self.slope_ = None
+
+    def fit(self, X: np.ndarray, y: np.ndarray):
+        X = np.asarray(X, dtype=float).reshape(-1)
+        y = np.asarray(y, dtype=float).reshape(-1)
+        if X.shape[0] != y.shape[0]:
+            raise ValueError("X and y must have same length")
+        n = X.shape[0]
+        Sx = X.sum()
+        Sy = y.sum()
+        Sxx = float(np.dot(X, X))
+        Sxy = float(np.dot(X, y))
+        if self.fit_intercept:
+            den = n * Sxx - Sx * Sx
+            if den == 0:
+                raise ZeroDivisionError("Denominator is zero (all x identical?).")
+            b = (n * Sxy - Sx * Sy) / den
+            a = (Sy - b * Sx) / n
+        else:
+            if Sxx == 0:
+                raise ZeroDivisionError("Sxx is zero (all x are zero?).")
+            b = Sxy / Sxx
+            a = 0.0
+        self.intercept_ = float(a)
+        self.slope_ = float(b)
+        return self
+
+    def predict(self, X: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        if self.slope_ is None:
+            raise ValueError("Model not fit.")
+        return self.intercept_ + self.slope_ * X
+
+    def score(self, X: np.ndarray, y: np.ndarray) -> float:
+        yhat = self.predict(X)
+        u = y - yhat
+        v = y - y.mean() if self.fit_intercept else y
+        den = float(np.dot(v, v))
+        return 1.0 - float(np.dot(u, u)) / den if den != 0.0 else 0.0
+import numpy as np
+from typing import Tuple, Union
+# CME 193 - Lec 2: Univariate OLS via OOP
+
+We’ll implement ordinary least squares for one variable in two forms:
+- UnivariateOLS: batch fit
+- UnivariateOnlineOLS: streaming updates with `__add__`/`__iadd__`
+
+Both support an optional intercept.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 mkdocs>=1.6.0
 mkdocs-material>=9.5.17
 pymdown-extensions>=10.11.2
+numpy>=1.25
+scikit-learn>=1.3
+matplotlib>=3.7


### PR DESCRIPTION
Replaced the animal/bank account OOP example in `Lecture_2_Intro_OOP.ipynb` with a streaming Ordinary Least Squares (OLS) example and created `Lecture_2_Online_OLS.ipynb` to align with scientific Python and machine learning concepts.

The previous examples were not relevant to the course's focus. This PR introduces a streaming Ordinary Least Squares (OLS) estimator, demonstrating OOP principles through `__add__` and `__iadd__` for adding observations, and an API consistent with scikit-learn (`coef_`, `intercept_`, `predict`, `score`). This provides a more engaging and relevant context for teaching OOP in a scientific computing curriculum. `requirements.txt` was also updated to include `numpy`, `scikit-learn`, and `matplotlib`.

---
<a href="https://cursor.com/background-agent?bcId=bc-30b5563a-457f-4587-b67e-031fd8cf20b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-30b5563a-457f-4587-b67e-031fd8cf20b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

